### PR TITLE
Undo/Redo history visualization

### DIFF
--- a/site/components/UnicornEditor/index.js
+++ b/site/components/UnicornEditor/index.js
@@ -22,7 +22,7 @@ const stickerPluginInstance = stickerPlugin({
   stickers,
 });
 const { StickerSelect } = stickerPluginInstance;
-const { UndoButton, RedoButton } = historyPluginInstance;
+const { UndoButton, RedoButton, History } = historyPluginInstance;
 
 const plugins = [
   hashtagPluginInstance,
@@ -99,6 +99,7 @@ export default class UnicornEditor extends Component {
           editorState={ this.state.editorState }
           collapsed={ !this.state.showState }
         />
+      <History editorState={ this.state.editorState } />
 
         <h3>Features in this Editor via Plugins</h3>
         <ul>

--- a/src/historyPlugin/History/HistoryEntry/index.js
+++ b/src/historyPlugin/History/HistoryEntry/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import styles from './styles';
+
+const HistoryEntry = (props) => (
+  <div style={ styles.root } { ...props } />
+);
+
+export default HistoryEntry;

--- a/src/historyPlugin/History/HistoryEntry/styles.js
+++ b/src/historyPlugin/History/HistoryEntry/styles.js
@@ -1,0 +1,3 @@
+export default {
+  root: {}
+}

--- a/src/historyPlugin/History/HistoryEntry/styles.js
+++ b/src/historyPlugin/History/HistoryEntry/styles.js
@@ -1,3 +1,3 @@
 export default {
-  root: {}
-}
+  root: {},
+};

--- a/src/historyPlugin/History/index.js
+++ b/src/historyPlugin/History/index.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import { EditorState } from 'draft-js-cutting-edge';
 
 import HistoryEntry from './HistoryEntry';
 import styles from './styles';

--- a/src/historyPlugin/History/index.js
+++ b/src/historyPlugin/History/index.js
@@ -1,0 +1,42 @@
+import React, { Component, PropTypes } from 'react';
+import { EditorState } from 'draft-js-cutting-edge';
+
+import HistoryEntry from './HistoryEntry';
+import styles from './styles';
+
+class History extends Component {
+  generateHistoryEntries(stack, style) {
+    return stack.map((entry) => (
+      <HistoryEntry style={style} >
+        { entry.getPlainText() }
+      </HistoryEntry>
+    ));
+  }
+
+  render() {
+    const undoStack = this.props.editorState.getUndoStack();
+    const redoStack = this.props.editorState.getRedoStack().reverse();
+    const undoHistory = this.generateHistoryEntries(undoStack, styles.entry);
+    const redoHistory = this.generateHistoryEntries(redoStack, styles.entry);
+    const currentEntryStyle = {
+      ...styles.entry,
+      color: '#000',
+    };
+
+    return (
+      <div>
+        { redoHistory }
+        <HistoryEntry style={ currentEntryStyle }>
+          { this.props.editorState.getCurrentContent().getPlainText() }
+        </HistoryEntry>
+        { undoHistory }
+      </div>
+    );
+  }
+}
+
+History.propTypes = {
+  editorState: PropTypes.any.isRequired,
+};
+
+export default History;

--- a/src/historyPlugin/History/styles.js
+++ b/src/historyPlugin/History/styles.js
@@ -2,4 +2,4 @@ export default {
   entry: {
     color: '#999',
   },
-}
+};

--- a/src/historyPlugin/History/styles.js
+++ b/src/historyPlugin/History/styles.js
@@ -1,0 +1,5 @@
+export default {
+  entry: {
+    color: '#999',
+  },
+}

--- a/src/historyPlugin/README.md
+++ b/src/historyPlugin/README.md
@@ -26,3 +26,15 @@ Which take two props, `onChange` (a function that takes a new editor state as an
 <UndoButton onChange={ this.onChange } editorState={ this.state.editorState } />
 <RedoButton onChange={ this.onChange } editorState={ this.state.editorState } />
 ```
+
+## Visualization
+
+You can visualize your history with the `History` component, used like this:
+
+```JS
+import { History } from historyPluginInstance;
+```
+
+```HTML
+<History editorState={ this.state.editorState } />
+```

--- a/src/historyPlugin/index.js
+++ b/src/historyPlugin/index.js
@@ -1,9 +1,11 @@
 import UndoButton from './UndoButton';
 import RedoButton from './RedoButton';
+import History from './History';
 
 const historyPlugin = () => ({
   UndoButton,
   RedoButton,
+  History,
 });
 
 export default historyPlugin;


### PR DESCRIPTION
Ref #48, you can now visualize your undo/redo history with the <History> component!

It looks like this:

![historyplugin](https://cloud.githubusercontent.com/assets/7525670/13553412/d7c5328c-e388-11e5-8376-7217eb7f5323.gif)

And works like this:

```HTML
<History editorState={ this.state.editorState } />
```