### PR TITLE
feat(Mentions): adding hover state and filtering for mentions

### DIFF
--- a/src/mentionPlugin/MentionSearch/MentionOption/index.js
+++ b/src/mentionPlugin/MentionSearch/MentionOption/index.js
@@ -6,15 +6,35 @@ import styles from './styles';
 
 export default class MentionOption extends Component {
 
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
   onMentionSelect = () => {
     this.props.onMentionSelect(this.props.mention);
   };
 
+  onMouseOver = () => {
+    this.setState({
+      hovered: true
+    });
+  };
+
+  onMouseOut = () => {
+    this.setState({
+      hovered: false
+    });
+  };
+
   render() {
+    const style = this.state.hovered ? styles.hovered : styles.root;
     return (
       <div
-        style={ styles.root }
+        style={ style }
         onClick={ this.onMentionSelect }
+        onMouseOver={ this.onMouseOver }
+        onMouseOut={ this.onMouseOut }
       >
         { this.props.mention.get('handle') }
       </div>

--- a/src/mentionPlugin/MentionSearch/MentionOption/styles.js
+++ b/src/mentionPlugin/MentionSearch/MentionOption/styles.js
@@ -5,4 +5,12 @@ export default {
     borderBottom: '1px solid #ddd',
     padding: 5,
   },
+  hovered: {
+    // I am copying root styles also to hovered so that during
+    // render we do not need to merge the objects to create anew object each time.
+    borderBottom: '1px solid #ddd',
+    padding: 5,
+    backgroundColor: '#000080',
+    color: 'white',
+  },
 };

--- a/src/mentionPlugin/MentionSearch/index.js
+++ b/src/mentionPlugin/MentionSearch/index.js
@@ -14,12 +14,16 @@ export default (mentions) => {
     };
 
     // Get the first 5 mentions that match
-    getMentionsForFilter = () => (
-      mentions
+    getMentionsForFilter = () => {
 
-      // TODO better search algorithm than startsWith
-      // mentions.filter((mention) => mention.get('handle').startsWith(this.mentionSearch)).slice(0, 10)
-    );
+      const userEntered = this.props.editor.props.editorState.getCurrentContent().getLastBlock().getText();
+      const lastMentionStarts = userEntered.lastIndexOf("@");
+      const mentionValue = userEntered.substring(lastMentionStarts + 1, userEntered.length);
+      let filteredValues = mentions && mentions.filter((mention) =>
+        !mentionValue || mention.get('handle').toLowerCase().indexOf(mentionValue.toLowerCase()) > -1);
+      const size = filteredValues.size < 5 ? filteredValues.size : 5;
+      return filteredValues.setSize(size);
+    };
 
     renderItemForMention = (mention) => (
 
@@ -34,10 +38,12 @@ export default (mentions) => {
     render() {
       // TODO ask issac to provide begin & end down to the component as prop (in decorators)
       this.lastSelection = this.props.editor.props.editorState.getSelection();
+      const filteredMentions = this.getMentionsForFilter();
       return (
         <span {...this.props} style={ styles.root }>
           { this.props.children }
-          <Dropdown>
+          { filteredMentions.size > 0 ?
+            <Dropdown>
             {
               this.getMentionsForFilter().map((mention) => (
                 <MentionOption
@@ -48,6 +54,7 @@ export default (mentions) => {
               ))
             }
           </Dropdown>
+          : void 0}
         </span>
       );
     }


### PR DESCRIPTION
Hey @nikgraf,

PR has changes for:
1. Adding hovered state to dropdown options.
2. Adding filtering for mentions, the filtering logic is that text entered by the user can be anywhere in option and it returns first 5 options filtered.

I could not add keyboard handling as keystrokes are handled at level of editor and are currently not communicated over to plugins. Since dropdown is not focused it can not get keyDown event. We should create hook for these events in plugins which can be called by editor.